### PR TITLE
Specify CWT tag in EAT CDDL

### DIFF
--- a/specifications/ietf-eat-profile/cddl/ietf_eat_ocp_profile.cddl
+++ b/specifications/ietf-eat-profile/cddl/ietf_eat_ocp_profile.cddl
@@ -53,5 +53,8 @@ unprotected-ce-header-map = {
   * cose-label => cose-value
 }
 
+; Explictly identify the CWT using its tag.
+cwt = #6.61(signed-cwt)
+
 ; Explicitly assert that CWT is encoded as CBOR with the self-described CBOR tag.
-ocp-evidence-eat = #6.55799(signed-cwt)
+ocp-evidence-eat = #6.55799(cwt)


### PR DESCRIPTION
This fulfils one of the requirements for a full EAT profile, and errs on the side of explicitness.