### PR TITLE
EAT: upgrade the spec version to 1.0

### DIFF
--- a/specifications/ietf-eat-profile/spec.ocp
+++ b/specifications/ietf-eat-profile/spec.ocp
@@ -1,6 +1,6 @@
 ---
-title: "OCP Profile for IETF Entity Attestation Token (Draft)"
-version: 0.1
+title: "OCP Profile for IETF Entity Attestation Token"
+version: "1.0"
 type: BASE
 project: Security
 authors: [(See Acknowledgements section)]


### PR DESCRIPTION
The OID assignment makes the specification immutable, effectively freezing the definition. 
Updating the version to 1.0.